### PR TITLE
Modded MNIST Demo with Dataloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+Reproducibility/data
+Reproducibility/pl-mnist
+Reproducibility/wandb
+
+venv/

--- a/Reproducibility/mod_mnist_demo.ipynb
+++ b/Reproducibility/mod_mnist_demo.ipynb
@@ -1,0 +1,356 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Modified MNIST Demo\n",
+    "\n",
+    "Modifying the code from our CoE 197 class to use the dataset provided in /data/imagenet/ for training and testing.\n",
+    "Added model checkpoint callback to save model with best test_acc."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Image Recognition on MNIST using PyTorch Lightning\n",
+    "\n",
+    "Demonstrating the elements of machine learning:\n",
+    "\n",
+    "1) **E**xperience (Datasets and Dataloaders)<br>\n",
+    "2) **T**ask (Classifier Model)<br>\n",
+    "3) **P**erformance (Accuracy)<br>\n",
+    "\n",
+    "**Experience:** <br>\n",
+    "We use MNIST dataset for this demo. MNIST is made of 28x28 images of handwritten digits, `0` to `9`. The train split has 60,000 images and the test split has 10,000 images. Images are all gray-scale.\n",
+    "\n",
+    "**Task:**<br>\n",
+    "Our task is to classify the images into 10 classes. We use ResNet18 model from torchvision.models. The ResNet18 first convolutional layer (`conv1`) is modified to accept a single channel input. The number of classes is set to 10.\n",
+    "\n",
+    "**Performance:**<br>\n",
+    "We use accuracy metric to evaluate the performance of our model on the test split. `torchmetrics.functional.accuracy`  calculates the accuracy.\n",
+    "\n",
+    "**[Pytorch Lightning](https://www.pytorchlightning.ai/):**<br>\n",
+    "Our demo uses Pytorch Lightning to simplify the process of training and testing. Pytorch Lightning `Trainer` trains and evaluates our model. The default configurations are for a GPU-enabled system with 48 CPU cores. Please change the configurations if you have a different system.\n",
+    "\n",
+    "**[Weights and Biases](https://www.wandb.ai/):**<br>\n",
+    "`wandb` is used by PyTorch Lightining Module to log train and evaluations results. Use `--no-wandb` to disable `wandb`.\n",
+    "\n",
+    "\n",
+    "Let us install `pytorch-lightning` and `torchmetrics`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install pytorch-lightning --upgrade\n",
+    "%pip install torchmetrics --upgrade"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torchvision\n",
+    "import os\n",
+    "import wandb\n",
+    "from argparse import ArgumentParser\n",
+    "from pytorch_lightning import LightningModule, Trainer, LightningDataModule, Callback\n",
+    "from pytorch_lightning.callbacks import ModelCheckpoint\n",
+    "from pytorch_lightning.loggers import WandbLogger\n",
+    "from torchmetrics.functional import accuracy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Custom Data Loader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ImageNetDataModule(LightningDataModule):\n",
+    "    def __init__(self, path, batch_size=128, num_workers=0, class_dict={}, \n",
+    "                 **kwargs):\n",
+    "        super().__init__(**kwargs)\n",
+    "        self.path = path\n",
+    "        self.batch_size = batch_size\n",
+    "        self.num_workers = num_workers\n",
+    "        self.class_dict = class_dict\n",
+    "\n",
+    "    def prepare_data(self):\n",
+    "        self.transform = torchvision.transforms.Compose([\n",
+    "            torchvision.transforms.Grayscale(),\n",
+    "            torchvision.transforms.CenterCrop(100),\n",
+    "            torchvision.transforms.ToTensor(),\n",
+    "            ])\n",
+    "\n",
+    "        self.train_dataset = torchvision.datasets.ImageNet(\"/data/imagenet/\", split='train', transform=self.transform)\n",
+    "                                                                \n",
+    "        self.val_dataset = self.train_dataset\n",
+    "\n",
+    "        self.test_dataset = torchvision.datasets.ImageNet(\"/data/imagenet/\", split='val', transform=self.transform)\n",
+    "\n",
+    "    def setup(self, stage=None):\n",
+    "        self.prepare_data()\n",
+    "\n",
+    "    def train_dataloader(self):\n",
+    "        return torch.utils.data.DataLoader(\n",
+    "            self.train_dataset,\n",
+    "            batch_size=self.batch_size,\n",
+    "            num_workers=self.num_workers,\n",
+    "            shuffle=True,\n",
+    "            pin_memory=True,\n",
+    "        )\n",
+    "\n",
+    "    def val_dataloader(self):\n",
+    "        return torch.utils.data.DataLoader(\n",
+    "            self.val_dataset,\n",
+    "            batch_size=self.batch_size,\n",
+    "            num_workers=self.num_workers,\n",
+    "            shuffle=False,\n",
+    "            pin_memory=True,\n",
+    "        )\n",
+    "    \n",
+    "    def test_dataloader(self):\n",
+    "        return torch.utils.data.DataLoader(\n",
+    "            self.test_dataset,\n",
+    "            batch_size=self.batch_size,\n",
+    "            num_workers=self.num_workers,\n",
+    "            shuffle=False,\n",
+    "            pin_memory=True,\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pytorch Lightning Module\n",
+    "\n",
+    "PyTorch Lightning Module has a PyTorch ResNet18 Model. It is a subclass of LightningModule. The model part is subclassed to support a single channel input. We replaced the input convolutional layer to support single channel inputs. The Lightning Module is also a container for the model, the optimizer, the loss function, the metrics, and the data loaders.\n",
+    "\n",
+    "`ResNet` class can be found [here](https://pytorch.org/vision/0.8/_modules/torchvision/models/resnet.html).\n",
+    "\n",
+    "By using PyTorch Lightning, we simplify the training and testing processes since we do not need to write boiler plate code blocks. These include automatic transfer to chosen device (i.e. `gpu` or `cpu`), model `eval` and `train` modes, and backpropagation routines."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class LitMNISTModel(LightningModule):\n",
+    "    def __init__(self, num_classes=10, lr=0.001, batch_size=32):\n",
+    "        super().__init__()\n",
+    "        self.save_hyperparameters()\n",
+    "        self.model = torchvision.models.resnet18(num_classes=num_classes)\n",
+    "        self.model.conv1 = torch.nn.Conv2d(1, 64, kernel_size=7,\n",
+    "                                           stride=2, padding=3, bias=False)\n",
+    "        self.loss = torch.nn.CrossEntropyLoss()\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        return self.model(x)\n",
+    "\n",
+    "    # this is called during fit()\n",
+    "    def training_step(self, batch, batch_idx):\n",
+    "        x, y = batch\n",
+    "        y_hat = self.forward(x)\n",
+    "        loss = self.loss(y_hat, y)\n",
+    "        return {\"loss\": loss}\n",
+    "\n",
+    "    # calls to self.log() are recorded in wandb\n",
+    "    def training_epoch_end(self, outputs):\n",
+    "        avg_loss = torch.stack([x[\"loss\"] for x in outputs]).mean()\n",
+    "        self.log(\"train_loss\", avg_loss, on_epoch=True)\n",
+    "\n",
+    "    # this is called at the end of an epoch\n",
+    "    def test_step(self, batch, batch_idx):\n",
+    "        x, y = batch\n",
+    "        y_hat = self.forward(x)\n",
+    "        loss = self.loss(y_hat, y)\n",
+    "        acc = accuracy(y_hat, y) * 100.\n",
+    "        # we use y_hat to display predictions during callback\n",
+    "        return {\"y_hat\": y_hat, \"test_loss\": loss, \"test_acc\": acc}\n",
+    "\n",
+    "    # this is called at the end of all epochs\n",
+    "    def test_epoch_end(self, outputs):\n",
+    "        avg_loss = torch.stack([x[\"test_loss\"] for x in outputs]).mean()\n",
+    "        avg_acc = torch.stack([x[\"test_acc\"] for x in outputs]).mean()\n",
+    "        self.log(\"test_loss\", avg_loss, on_epoch=True, prog_bar=True)\n",
+    "        self.log(\"test_acc\", avg_acc, on_epoch=True, prog_bar=True)\n",
+    "\n",
+    "    # validation is the same as test\n",
+    "    def validation_step(self, batch, batch_idx):\n",
+    "       return self.test_step(batch, batch_idx)\n",
+    "\n",
+    "    def validation_epoch_end(self, outputs):\n",
+    "        return self.test_epoch_end(outputs)\n",
+    "\n",
+    "    # we use Adam optimizer\n",
+    "    def configure_optimizers(self):\n",
+    "        return torch.optim.Adam(self.parameters(), lr=self.hparams.lr)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### PyTorch Lightning Callback\n",
+    "\n",
+    "We can instantiate a callback object to perform certain tasks during training. In this case, we log sample images, ground truth labels, and predicted labels from the test dataset.\n",
+    "\n",
+    "We can also `ModelCheckpoint` callback to save the model after each epoch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class WandbCallback(Callback):\n",
+    "\n",
+    "    def on_validation_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx):\n",
+    "        # process first 10 images of the first batch\n",
+    "        if batch_idx == 0:\n",
+    "            n = 10\n",
+    "            x, y = batch\n",
+    "            outputs = outputs[\"y_hat\"]\n",
+    "            outputs = torch.argmax(outputs, dim=1)\n",
+    "            # log image, ground truth and prediction on wandb table\n",
+    "            columns = ['image', 'ground truth', 'prediction']\n",
+    "            data = [[wandb.Image(x_i), y_i, y_pred] for x_i, y_i, y_pred in list(\n",
+    "                zip(x[:n], y[:n], outputs[:n]))]\n",
+    "            wandb_logger.log_table(\n",
+    "                key='ResNet18 on ImageNet Predictions',\n",
+    "                columns=columns,\n",
+    "                data=data)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Program Arguments\n",
+    "\n",
+    "When running on command line, we can pass arguments to the program. For the jupyter notebook, we can pass arguments using the `%run` magic command.\n",
+    "\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_args():\n",
+    "    parser = ArgumentParser(description=\"PyTorch Lightning MNIST Example\")\n",
+    "    parser.add_argument(\"--max-epochs\", type=int, default=5, help=\"num epochs\")\n",
+    "    parser.add_argument(\"--batch-size\", type=int, default=32, help=\"batch size\")\n",
+    "    parser.add_argument(\"--lr\", type=float, default=0.001, help=\"learning rate\")\n",
+    "\n",
+    "    parser.add_argument(\"--path\", type=str, default=\"./\")\n",
+    "\n",
+    "    parser.add_argument(\"--num-classes\", type=int, default=1000, help=\"num classes\")\n",
+    "\n",
+    "    parser.add_argument(\"--devices\", default=1)\n",
+    "    parser.add_argument(\"--accelerator\", default='gpu')\n",
+    "    parser.add_argument(\"--num-workers\", type=int, default=48, help=\"num workers\")\n",
+    "    \n",
+    "    parser.add_argument(\"--no-wandb\", default=False, action='store_true')\n",
+    "    args = parser.parse_args(\"\")\n",
+    "    return args"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Training and Evaluation using `Trainer`\n",
+    "\n",
+    "Get command line arguments. Instatiate a Pytorch Lightning Model. Train the model. Evaluate the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    args = get_args()\n",
+    "    model = LitMNISTModel(num_classes=args.num_classes,\n",
+    "                          lr=args.lr, batch_size=args.batch_size)\n",
+    "    datamodule = ImageNetDataModule(path=args.path, batch_size=args.batch_size, num_workers=args.num_workers)\n",
+    "    datamodule.setup()\n",
+    "\n",
+    "    # printing the model is useful for debugging\n",
+    "    print(model)\n",
+    "\n",
+    "    # wandb is a great way to debug and visualize this model\n",
+    "    wandb_logger = WandbLogger(project=\"pl-mnist\")\n",
+    "\n",
+    "    model_checkpoint = ModelCheckpoint(\n",
+    "        dirpath=os.path.join(args.path, \"checkpoints\"),\n",
+    "        filename=\"resnet18-mnist-best-acc\",\n",
+    "        save_top_k=1,\n",
+    "        verbose=True,\n",
+    "        monitor='test_acc',\n",
+    "        mode='max',\n",
+    "    )\n",
+    "    \n",
+    "    trainer = Trainer(accelerator=args.accelerator,\n",
+    "                      devices=args.devices,\n",
+    "                      max_epochs=args.max_epochs,\n",
+    "                      logger=wandb_logger if not args.no_wandb else None,\n",
+    "                      callbacks=[model_checkpoint, WandbCallback() if not args.no_wandb else None])\n",
+    "    trainer.fit(model, datamodule=datamodule)\n",
+    "    trainer.test(model, datamodule=datamodule)\n",
+    "\n",
+    "    wandb.finish()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.8.10 ('venv': venv)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "5649ecf95a7c37ba7d0fd0df7920912d640f9d10415c6c6447a845135a6530c9"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Reproducibility/requirements.txt
+++ b/Reproducibility/requirements.txt
@@ -1,0 +1,13 @@
+# For jupyter to run with venv
+ipykernel
+# For jupyter to run in tmux
+# jupyter nbconvert --to notebook --execute mod_mnist_demo.ipynb --output mod_mnist_demo.ipynb
+nbconvert
+
+pytorch-lightning
+torchmetrics
+
+torch>=1.8.11
+torchvision>=0.9.1
+
+wandb


### PR DESCRIPTION
I've modded the MNIST demo in [the CoE 197 repo](https://github.com/roatienza/Deep-Learning-Experiments/tree/master/versions/2022/supervised/python) to use the ImageNet train dir as training data and val dir as testing data. I have also modded it to save the best accuracy model using Model Checkpoint. Please verify.